### PR TITLE
Move --gc:arc to config.nims

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out the [screenshots on the wiki](https://github.com/codic12/worm/wiki/Scr
 Install Nim >= 1.6.0, for example through Choosenim. Clone this repo and run
 
 ```
-$ nimble build -d:release --gc:arc
+$ nimble build -d:release
 ```
 And you should end up with two binaries; strip and use!
 

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,1 @@
+switch("gc", "arc")


### PR DESCRIPTION
No real reason to have the user set this config option when it can just live in the project-local config.nims.