### PR TITLE
Allow setting rcfile path via flag

### DIFF
--- a/src/events.nim
+++ b/src/events.nim
@@ -1,8 +1,6 @@
 import
-  std/[os, osproc],
   x11/[x, xlib],
   wm,
-  log,
   events/[
     buttonpress,
     buttonrelease,
@@ -33,10 +31,6 @@ proc dispatchEvent*(self: var Wm; ev: XEvent) =
   else: discard
 
 proc eventLoop*(self: var Wm) =
-  if fileExists expandTilde "~/.config/worm/rc":
-    log "config file found, loading..."
-    discard startProcess expandTilde "~/.config/worm/rc"
-    log "config file loaded!"
   while true:
     discard self.dpy.XNextEvent(unsafeAddr self.currEv)
     self.dispatchEvent self.currEv

--- a/src/worm.nim
+++ b/src/worm.nim
@@ -1,7 +1,29 @@
 import
+  std/[os, osproc, parseopt],
   wm,
-  events
+  events,
+  log
 
 when isMainModule:
   var instance = initWm()
+
+  var rcFile = "~/.config/worm/rc"
+
+  var p = initOptParser("")
+  while true:
+    p.next()
+    case p.kind
+    of cmdEnd: break
+    of cmdLongOption:
+      case p.key
+      of "rcfile":
+        rcFile = p.val
+      else: discard
+    else: discard
+
+  if fileExists expandTilde rcFile:
+    log "config file found, loading..."
+    discard startProcess expandTilde rcFile
+    log "config file loaded!"
+
   instance.eventLoop()


### PR DESCRIPTION
Also moves rcfile loading to worm.nim rather than events.nim, which feels more sensible.

I kept this simple and used `std/parseopt` because I didn't really want to pull in a dependency for command-line parsing since you weren't using one in `wormc`, but if using something more robust would be preferred I can do that instead (this is also why I only added a long opt and not a short one, since parseopt usage is quite verbose).