### PR TITLE
Bump version in worm.nimble

### DIFF
--- a/worm.nimble
+++ b/worm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.5"
 author        = "codic12"
 description   = "Window manager "
 license       = "MIT"


### PR DESCRIPTION
Latest release is 0.2.5

Depending on your repo management strategy this could also be 0.2.6 (as 0.2.5 has already been released, so `main` would be staging for the next version)