### PR TITLE
Fix GTK drag & drop and xprop

### DIFF
--- a/src/events/maprequest.nim
+++ b/src/events/maprequest.nim
@@ -94,6 +94,17 @@ proc handleMapRequest*(self: var Wm; ev: XMapRequestEvent): void =
   discard self.dpy.XSelectInput(ev.window, PropertyChangeMask)
   discard self.dpy.XReparentWindow(ev.window, frame, 0,
       cint frameHeight)
+  # WM_NAME must be set for GTK drag&drop and xprop
+  let wm_state: uint8 = NormalState
+  discard self.dpy.XChangeProperty(
+    ev.window,
+    self.dpy.XInternAtom("WM_STATE".cstring, false),
+    XaWindow,
+    8,
+    PropModeReplace,
+    cast[cstring](unsafeAddr wm_state),
+    1
+  )
   let top = self.dpy.XCreateWindow(frame, 0, 0,
       cuint attr.width, cuint frameHeight, 0, attr.depth,
       InputOutput,

--- a/src/events/maprequest.nim
+++ b/src/events/maprequest.nim
@@ -94,7 +94,7 @@ proc handleMapRequest*(self: var Wm; ev: XMapRequestEvent): void =
   discard self.dpy.XSelectInput(ev.window, PropertyChangeMask)
   discard self.dpy.XReparentWindow(ev.window, frame, 0,
       cint frameHeight)
-  # WM_NAME must be set for GTK drag&drop and xprop
+  # WM_STATE must be set for GTK drag&drop and xprop
   # https://github.com/i3/i3/blob/dba30fc9879b42e6b89773c81e1067daa2bb6e23/src/x.c#L1065
   let wm_state: uint8 = NormalState
   discard self.dpy.XChangeProperty(

--- a/src/events/maprequest.nim
+++ b/src/events/maprequest.nim
@@ -95,6 +95,7 @@ proc handleMapRequest*(self: var Wm; ev: XMapRequestEvent): void =
   discard self.dpy.XReparentWindow(ev.window, frame, 0,
       cint frameHeight)
   # WM_NAME must be set for GTK drag&drop and xprop
+  # https://github.com/i3/i3/blob/dba30fc9879b42e6b89773c81e1067daa2bb6e23/src/x.c#L1065
   let wm_state: uint8 = NormalState
   discard self.dpy.XChangeProperty(
     ev.window,


### PR DESCRIPTION
Closes #52.

Turns out that the section I found in i3's source code when first diagnosing the issue was exactly what I needed.

Also, it turns out xprop was also broken by WM_STATE not being set! Go figure.

It's not exactly as clean as the rest of your XChangeProperty calls since WM_STATE was neither in netAtoms or ipcAtoms, but I wasn't sure where I should put a new atom so I just interned it inline.