### PR TITLE
Fixup WM_STATE type mismatch

### DIFF
--- a/src/events/maprequest.nim
+++ b/src/events/maprequest.nim
@@ -96,12 +96,12 @@ proc handleMapRequest*(self: var Wm; ev: XMapRequestEvent): void =
       cint frameHeight)
   # WM_STATE must be set for GTK drag&drop and xprop
   # https://github.com/i3/i3/blob/dba30fc9879b42e6b89773c81e1067daa2bb6e23/src/x.c#L1065
-  let wm_state: uint8 = NormalState
+  let wm_state: uint32 = NormalState
   discard self.dpy.XChangeProperty(
     ev.window,
     self.dpy.XInternAtom("WM_STATE".cstring, false),
     XaWindow,
-    8,
+    32,
     PropModeReplace,
     cast[cstring](unsafeAddr wm_state),
     1


### PR DESCRIPTION
Fixes an error with the implementation of #53. It seems WM_STATE is expected to be 32 bits, but I had passed it as a uint8 instead.

Prior to the fix, `xprop` (on an xterm window) reports:
```
WM_STATE(WINDOW): Type mismatch: assumed size 32 bits, actual size 8 bits.
```

After applied, it reports:
```
WM_STATE(WINDOW):
                window state: Normal
                icon window: <field not available>
```