### PR TITLE
Remove tap grab

### DIFF
--- a/src/events/maprequest.nim
+++ b/src/events/maprequest.nim
@@ -162,7 +162,7 @@ proc handleMapRequest*(self: var Wm; ev: XMapRequestEvent): void =
     for win in [close, maximize, minimize]: discard self.dpy.XGrabButton(1, mask, win,
         true, ButtonPressMask or PointerMotionMask, GrabModeAsync, GrabModeAsync,
             None, None)
-  for mask in [uint32 0, Mod2Mask, LockMask,
+  for mask in [uint32 Mod2Mask, LockMask,
          Mod3Mask, Mod2Mask or LockMask,
         LockMask or Mod3Mask, Mod2Mask or Mod3Mask,
         Mod2Mask or LockMask or Mod3Mask]:


### PR DESCRIPTION
Closes #62.

As far as I can tell there are no negative effects from this.

Is there a reason worm needs to capture unmodified buttonpress events on the windows themselves?

Also, border-dragging still works with this solution, so that's a plus.