### PR TITLE
Quickfix tap grab

### DIFF
--- a/src/events/buttonpress.nim
+++ b/src/events/buttonpress.nim
@@ -73,8 +73,9 @@ proc handleButtonPress*(self: var Wm; ev: XButtonEvent): void =
       self.minimizeClient client[]
       quitMinimize = true
   if quitMaximize: return
-  discard self.dpy.XGrabPointer(client.frame.window, true, PointerMotionMask or
-      ButtonReleaseMask, GrabModeAsync, GrabModeAsync, None, None, CurrentTime)
+  if client.window != ev.window:
+    discard self.dpy.XGrabPointer(client.frame.window, true, PointerMotionMask or
+        ButtonReleaseMask, GrabModeAsync, GrabModeAsync, None, None, CurrentTime)
   var attr: XWindowAttributes
   discard self.dpy.XGetWindowAttributes(client.frame.window, addr attr)
   self.motionInfo = some MotionInfo(start: ev, attr: attr)


### PR DESCRIPTION
Like I mention in #62, quick-tapping on the titlebar (or borders) will still initiate a drag (since worm apparently isn't catching my buttonrelease with a quick enough tap, as we've discussed), but this stops the majority of the issue since it only grabs if you're not on the window itself and instead clicking on the frame.

Since the vast majority of my intentional clicking is on the window itself this essentially solves the issue, although I'd still like to investigate a true fix on my own time -- other window managers I've used haven't had this problem on my laptop as far as I can tell, so I doubt it's unfixable.