### PR TITLE
Fix crash when setting text-inactive-pixel in rcfile

### DIFF
--- a/src/events/clientmessage.nim
+++ b/src/events/clientmessage.nim
@@ -210,6 +210,7 @@ proc handleClientMessage*(self: var Wm; ev: XClientMessageEvent) =
     elif ev.data.l[0] == clong self.ipcAtoms[IpcTextInactivePixel]:
       log "Chaging text inactive pixel to " & $ev.data.l[1]
       self.config.textInactivePixel = uint ev.data.l[1]
+      if self.focused.isNone: return
       self.raiseClient self.clients[self.focused.get]
     elif ev.data.l[0] == clong self.ipcAtoms[IpcTextFont]:
       log "IpcTextFont"


### PR DESCRIPTION
Prior to fix:
```
[lambdadog@taiga:~/devel/worm]$ DISPLAY=:1 ./worm
19:40:33 | INFO | wm.nim:35 | Opened display
19:40:33 | INFO | worm.nim:25 | config file found, loading...
19:40:33 | INFO | worm.nim:27 | config file loaded!
19:40:33 | INFO | clientmessage.nim:211 | Chaging text inactive pixel to -16777216
/home/lambdadog/devel/worm/src/worm.nim:29 worm
/home/lambdadog/devel/worm/src/events.nim:36 eventLoop
/home/lambdadog/devel/worm/src/events.nim:28 dispatchEvent
/home/lambdadog/devel/worm/src/events/clientmessage.nim:213 handleClientMessage
/nix/store/k66ff7hq2g0zllyjdv6ll1w8m18h38xj-nim-unwrapped-1.6.4/nim/lib/pure/options.nim:222 get
Error: unhandled exception: Can't obtain a value from a `none` [UnpackDefect]
```
